### PR TITLE
Add Rhesus TRG

### DIFF
--- a/rules/rules_rhesus_monkey.json
+++ b/rules/rules_rhesus_monkey.json
@@ -439,6 +439,69 @@
       "sources": [
         "http://www.imgt.org/genedb/GENElect?query=7.14+TRDJ&species=Macaca+mulatta"
       ]
-    }
+    },
+    {
+      "ruleType": "import",
+      "output": "output/rhesus_monkey_V_TRG",
+      "geneType": "V",
+      "chain": "TRG",
+      "anchorPoints": [
+        {
+          "point": "FR1Begin",
+          "position": 0
+        },
+        {
+          "point": "CDR1Begin",
+          "position": 78
+        },
+        {
+          "point": "FR2Begin",
+          "position": 114
+        },
+        {
+          "point": "CDR2Begin",
+          "position": 165
+        },
+        {
+          "point": "FR3Begin",
+          "position": 195
+        },
+        {
+          "point": "CDR3Begin",
+          "position": 309
+        },
+        {
+          "point": "VEnd",
+          "position": -1
+        }
+      ],
+      "sources": [
+        "http://www.imgt.org/genedb/GENElect?query=7.14+TRGV&species=Macaca+mulatta"
+      ]
+    },    
+    {
+      "ruleType": "import",
+      "output": "output/rhesus_monkey_J_TRG",
+      "geneType": "J",
+      "chain": "TRB",
+      "anchorPoints": [
+        {
+          "point": "JBegin",
+          "position": 0
+        },
+        {
+          "point": "FR4Begin",
+          "position": -28,
+          "aaPattern": "[WF](G.G)"
+        },
+        {
+          "point": "FR4End",
+          "position": -1
+        }
+      ],
+      "sources": [
+        "http://www.imgt.org/genedb/GENElect?query=7.14+TRGJ&species=Macaca+mulatta"
+      ]
+    }	
   ]
 }


### PR DESCRIPTION
@dbolotin @PoslavskySV: IMGT recently released TRG for rhesus macaque. I think supporting download of these data from the IMGT looks pretty simple - does this seem like a reasonable addition? I copied the anchor points from TRBV. In human, TRBV/TRVG were identical, so i assume that's just how IMGT formats them.